### PR TITLE
Enhance queue metrics tracking and cleanup for stale queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Note:** Prior to establishing this CHANGELOG.md file, release notes were maintained directly in [GitHub Releases](https://github.com/ottermq/ottermq/releases). Going forward, all changes will be tracked here and synchronized with releases.
 
+## [v0.19.3-2]
+
+### Fixed
+
+- **Metrics: negative queue message rate** — `PublishRate` and `DeliveryRate` per-queue rate trackers were being sampled with the current queue depth, which decreases as messages are consumed and produces negative rates. Added `PublishCount` and `DeliveryCount` monotonically increasing counters to `QueueMetrics`; rate trackers now sample these cumulative values (same pattern as `AckCount`).
+- **Prometheus: stale queue metrics after deletion** — per-queue `GaugeVec` label sets (`ottermq_queue_depth`, `ottermq_queue_message_rate`, `ottermq_queue_delivery_rate`, `ottermq_queue_ack_rate`, `ottermq_queue_consumers`, `ottermq_queue_unacked`) were never removed when a queue was deleted, causing Grafana to display the last-known value (e.g. a non-zero depth) indefinitely. The exporter now tracks the active queue set each cycle and calls `DeleteLabelValues` for any queue that no longer exists.
+
 ## [v0.19.3-1]
 
 ### Fixed

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -67,7 +67,8 @@ type QueueMetrics struct {
 	DeliveryRate *RateTracker // Messages delivered per second
 	AckRate      *RateTracker // ACKs per second
 	Depth        atomic.Int64 // Current queue depth
-	// Todo: add DeliveryCount atomic.Int64 // Total messages delivered
+	PublishCount  atomic.Int64 // Cumulative enqueue count (for rate calculation)
+	DeliveryCount atomic.Int64 // Cumulative delivery count (for rate calculation)
 	UnackedCount  atomic.Int64 // Current unacknowledged messages
 	ConsumerCount atomic.Int64 // Current consumer count
 	AckCount      atomic.Int64 // Cumulative ACK count (for rate calculation)
@@ -240,6 +241,7 @@ func (c *Collector) RecordQueuePublish(queueName string) {
 
 	qm := c.getOrCreateQueueMetrics(queueName)
 	qm.Depth.Add(1)
+	qm.PublishCount.Add(1)
 	c.readyDepth.Add(1)
 }
 
@@ -257,6 +259,7 @@ func (c *Collector) RecordQueueDelivery(queueName string, autoAck bool) {
 
 	qm := c.getOrCreateQueueMetrics(queueName)
 	qm.Depth.Add(-1)
+	qm.DeliveryCount.Add(1)
 	c.readyDepth.Add(-1)
 
 	if autoAck {
@@ -390,8 +393,8 @@ func (c *Collector) sampleQueueMetrics(queueName string) {
 	}
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
-	qm.PublishRate.Record(qm.Depth.Load())
-	qm.DeliveryRate.Record(qm.Depth.Load()) // TODO: change to DeliveryCount when implemented
+	qm.PublishRate.Record(qm.PublishCount.Load())
+	qm.DeliveryRate.Record(qm.DeliveryCount.Load())
 	qm.AckRate.Record(qm.AckCount.Load())
 }
 

--- a/web/prometheus/exporter.go
+++ b/web/prometheus/exporter.go
@@ -50,6 +50,9 @@ type Exporter struct {
 	// Delta tracking for per-exchange counters (keyed by exchange name)
 	lastExchangePublished map[string]int64
 
+	// Track known queues to detect deletions and clean up stale label sets
+	lastKnownQueues map[string]struct{}
+
 	stopChan chan struct{}
 	wg       sync.WaitGroup
 	mu       sync.Mutex
@@ -60,6 +63,7 @@ func NewExporter(collector *metrics.Collector, config *Config) *Exporter {
 		collector:             collector,
 		config:                config,
 		lastExchangePublished: make(map[string]int64),
+		lastKnownQueues:       make(map[string]struct{}),
 		stopChan:              make(chan struct{}),
 	}
 	e.registerMetrics()
@@ -228,8 +232,11 @@ func (e *Exporter) updateBroker() {
 }
 
 func (e *Exporter) updateQueues() {
+	currentQueues := make(map[string]struct{})
+
 	for _, qm := range e.collector.GetAllQueueMetrics() {
 		name := qm.Name
+		currentQueues[name] = struct{}{}
 		e.queueDepth.WithLabelValues(name).Set(float64(qm.Depth.Load()))
 		e.queueMessageRate.WithLabelValues(name).Set(qm.PublishRate.Rate())
 		e.queueDeliveryRate.WithLabelValues(name).Set(qm.DeliveryRate.Rate())
@@ -237,6 +244,20 @@ func (e *Exporter) updateQueues() {
 		e.queueConsumers.WithLabelValues(name).Set(float64(qm.ConsumerCount.Load()))
 		e.queueUnacked.WithLabelValues(name).Set(float64(qm.UnackedCount.Load()))
 	}
+
+	// Remove label sets for queues that no longer exist
+	for name := range e.lastKnownQueues {
+		if _, ok := currentQueues[name]; !ok {
+			e.queueDepth.DeleteLabelValues(name)
+			e.queueMessageRate.DeleteLabelValues(name)
+			e.queueDeliveryRate.DeleteLabelValues(name)
+			e.queueAckRate.DeleteLabelValues(name)
+			e.queueConsumers.DeleteLabelValues(name)
+			e.queueUnacked.DeleteLabelValues(name)
+		}
+	}
+
+	e.lastKnownQueues = currentQueues
 }
 
 func (e *Exporter) updateExchanges() {


### PR DESCRIPTION
Improve tracking of queue metrics by adding cumulative counts for published and delivered messages. Implement cleanup for stale metrics in Prometheus to ensure accurate reporting after queue deletions.