### PR TITLE
fix(amqp): bounds-check reply text length in Connection.Close parser

### DIFF
--- a/internal/core/amqp/connection.go
+++ b/internal/core/amqp/connection.go
@@ -254,6 +254,9 @@ func parseConnectionCloseFrame(payload []byte) (*RequestMethodMessage, error) {
 	index += 2
 	replyTextLen := payload[index]
 	index++
+	if len(payload) < int(index)+int(replyTextLen)+4 {
+		return nil, fmt.Errorf("frame too short")
+	}
 	replyText := string(payload[index : index+uint16(replyTextLen)])
 	index += uint16(replyTextLen)
 	classID := binary.BigEndian.Uint16(payload[index : index+2])

--- a/internal/core/amqp/connection_close_test.go
+++ b/internal/core/amqp/connection_close_test.go
@@ -1,0 +1,47 @@
+package amqp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// TestParseConnectionCloseFrame_ShortReplyText verifies that a Connection.Close
+// frame declaring a reply-text length longer than the remaining payload returns
+// an error instead of panicking with slice bounds out of range.
+func TestParseConnectionCloseFrame_ShortReplyText(t *testing.T) {
+	var payload bytes.Buffer
+	_ = binary.Write(&payload, binary.BigEndian, uint16(200)) // replyCode
+	payload.WriteByte(200)                                    // replyTextLen, but no reply text follows
+	for payload.Len() < 12 {                                  // pad past the len(payload) < 12 guard
+		payload.WriteByte(0)
+	}
+
+	_, err := parseConnectionCloseFrame(payload.Bytes())
+	if err == nil {
+		t.Fatal("Expected error for reply text length exceeding payload, got nil")
+	}
+}
+
+// TestParseConnectionCloseFrame_Valid confirms a well-formed frame still parses.
+func TestParseConnectionCloseFrame_Valid(t *testing.T) {
+	var payload bytes.Buffer
+	_ = binary.Write(&payload, binary.BigEndian, uint16(320)) // replyCode
+	replyText := "CONNECTION_FORCED"
+	payload.WriteByte(byte(len(replyText)))
+	payload.WriteString(replyText)
+	_ = binary.Write(&payload, binary.BigEndian, uint16(CONNECTION)) // classID
+	_ = binary.Write(&payload, binary.BigEndian, uint16(0))          // methodID
+
+	request, err := parseConnectionCloseFrame(payload.Bytes())
+	if err != nil {
+		t.Fatalf("parseConnectionCloseFrame failed: %v", err)
+	}
+	msg, ok := request.Content.(*ConnectionCloseMessage)
+	if !ok {
+		t.Fatalf("Expected *ConnectionCloseMessage, got %T", request.Content)
+	}
+	if msg.ReplyText != replyText {
+		t.Errorf("Expected reply text %q, got %q", replyText, msg.ReplyText)
+	}
+}


### PR DESCRIPTION
parseConnectionCloseFrame only guards against len(payload) < 12, then slices payload[index:index+replyTextLen] using a length byte read straight from the frame. A peer can send a Connection.Close frame whose declared replyTextLen exceeds the remaining payload, which panics with slice bounds out of range and takes down the broker goroutine. This adds a length check before the slice so a malformed frame returns an error instead, and covers it with a short-payload and a valid-frame test. Fixes #180.